### PR TITLE
Develop/swift 3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,5 +3,5 @@ import PackageDescription
 let package = Package(
     name: "Theo",
     dependencies: [],
-    exclude: []
+    exclude: ["Source/Theo/TheoTest"]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,7 @@
+import PackageDescription
+
+let package = Package(
+    name: "Theo",
+    dependencies: [],
+    exclude: []
+)

--- a/Package.swift
+++ b/Package.swift
@@ -3,5 +3,5 @@ import PackageDescription
 let package = Package(
     name: "Theo",
     dependencies: [],
-    exclude: ["Source/Theo/TheoTest"]
+    exclude: ["Source/Theo/TheoTests"]
 )

--- a/Source/Theo/Theo.xcodeproj/project.pbxproj
+++ b/Source/Theo/Theo.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		01FB2D1719C7DB5D00D429E7 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FB2D1319C7DB5D00D429E7 /* Session.swift */; };
 		01FB2D1919C7DBBF00D429E7 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FB2D1819C7DBBF00D429E7 /* Client.swift */; };
 		01FB2D1A19C7DBBF00D429E7 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01FB2D1819C7DBBF00D429E7 /* Client.swift */; };
+		85316C3B1E19A55F00CA3EB7 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85316C3A1E19A55F00CA3EB7 /* Package.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -45,6 +46,7 @@
 		01FB2D1219C7DB5D00D429E7 /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
 		01FB2D1319C7DB5D00D429E7 /* Session.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Session.swift; sourceTree = "<group>"; };
 		01FB2D1819C7DBBF00D429E7 /* Client.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
+		85316C3A1E19A55F00CA3EB7 /* Package.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Package.swift; path = ../../../Package.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -117,6 +119,7 @@
 		01FB2CC319C7DAB800D429E7 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				85316C3A1E19A55F00CA3EB7 /* Package.swift */,
 				01FB2CC419C7DAB800D429E7 /* Info.plist */,
 			);
 			name = "Supporting Files";
@@ -261,6 +264,7 @@
 				01422D2519D0B04A00B4B3B8 /* Relationship.swift in Sources */,
 				01FB2D1619C7DB5D00D429E7 /* Session.swift in Sources */,
 				017BB6E719E436E7007C57FD /* Cypher.swift in Sources */,
+				85316C3B1E19A55F00CA3EB7 /* Package.swift in Sources */,
 				01FB2D1419C7DB5D00D429E7 /* Request.swift in Sources */,
 				01FB2D1919C7DBBF00D429E7 /* Client.swift in Sources */,
 				019506C019CC61AB006F3596 /* Node.swift in Sources */,

--- a/Source/Theo/Theo.xcodeproj/project.pbxproj
+++ b/Source/Theo/Theo.xcodeproj/project.pbxproj
@@ -212,7 +212,6 @@
 					};
 					01FB2CCA19C7DAB800D429E7 = {
 						CreatedOnToolsVersion = 6.0;
-						DevelopmentTeam = XM4VAKDQL9;
 						LastSwiftMigration = 0810;
 					};
 				};
@@ -393,7 +392,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Theo/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.graphstory.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -414,7 +413,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = Theo/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.1;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.graphstory.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -426,7 +425,7 @@
 		01FB2CD719C7DAB800D429E7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = XM4VAKDQL9;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -446,7 +445,7 @@
 		01FB2CD819C7DAB800D429E7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				DEVELOPMENT_TEAM = XM4VAKDQL9;
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/Source/Theo/Theo/Info.plist
+++ b/Source/Theo/Theo/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Theo/Theo/Request.swift
+++ b/Source/Theo/Theo/Request.swift
@@ -232,10 +232,19 @@ class Request {
             return mutableRequest.copy() as! URLRequest
         }()
         
-        let task : URLSessionDataTask = self.httpSession.session.dataTask(with: request, completionHandler: {(data: Data?, response: URLResponse?, error: NSError?) -> Void in
+        let completionHandler = {(data: Data?, response: URLResponse?, error: Error?) -> Void in
             
             var dataResp: Data? = data
-            let httpResponse: HTTPURLResponse = response as! HTTPURLResponse
+            guard let httpResponse = response as? HTTPURLResponse else {
+                if let errorCallBack = errorBlock {
+                    let error = NSError(domain: "Invalid response", code: -1, userInfo: nil)
+                    let url: URL = request.url ?? URL(string: "http://invalid.com/error")!
+                    let response = URLResponse(url: url, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+                    errorCallBack(error, response)
+                }
+                return
+            }
+            
             let statusCode: Int = httpResponse.statusCode
             let containsStatusCode:Bool = Request.acceptableStatusCodes().contains(statusCode)
             
@@ -251,9 +260,10 @@ class Request {
             
             if let errorCallBack = errorBlock {
                 
-                if let error = error {
+                if let error = error { // How should this Error be NSError?
                     
-                    errorCallBack(error, httpResponse)
+                    let nserror = NSError(domain: "Theo Request", code: 1, userInfo: nil)
+                    errorCallBack(nserror, httpResponse)
                     return
                 }
                 
@@ -268,7 +278,9 @@ class Request {
                     errorCallBack(requestResponseError, httpResponse)
                 }
             }
-        } as! (Data?, URLResponse?, Error?) -> Void)
+            }
+            
+        let task : URLSessionDataTask = self.httpSession.session.dataTask(with: request, completionHandler:completionHandler)
         
         task.resume()
     }

--- a/Source/Theo/Theo/Request.swift
+++ b/Source/Theo/Theo/Request.swift
@@ -255,8 +255,9 @@ class Request {
             }
 
             /// Process Success Block
-            
-            successBlock?(dataResp, httpResponse)
+            if containsStatusCode {
+                successBlock?(dataResp, httpResponse)
+            }
             
             /// Process Error Block
             
@@ -325,7 +326,9 @@ class Request {
 
             /// Process Success Block
             
-            successBlock?(dataResp, httpResponse)
+            if containsStatusCode {
+                successBlock?(dataResp, httpResponse)
+            }
             
             /// Process Error Block
             

--- a/Source/Theo/Theo/Request.swift
+++ b/Source/Theo/Theo/Request.swift
@@ -165,13 +165,15 @@ class Request {
             let statusCode = httpResponse.statusCode
             let containsStatusCode:Bool = Request.acceptableStatusCodes().contains(statusCode)
 
-            if !containsStatusCode {
+            if containsStatusCode {
+                
+                /// Process Success Block
+                successBlock?(dataResp, httpResponse)
+
+            } else {
                 dataResp = nil
             }
       
-            /// Process Success Block
-            
-            successBlock?(dataResp, httpResponse)
     
             /// Process Error Block
             

--- a/Source/Theo/Theo/Request.swift
+++ b/Source/Theo/Theo/Request.swift
@@ -177,7 +177,7 @@ class Request {
             
             if let errorCallBack = errorBlock {
                 
-                if let error = error { // How should this Error be NSError?
+                if error != nil { // How should this Error be NSError?
                     
                     let nserror = NSError(domain: "Theo Request", code: 1, userInfo: nil)
                     errorCallBack(nserror, httpResponse)
@@ -260,7 +260,7 @@ class Request {
             
             if let errorCallBack = errorBlock {
                 
-                if let error = error { // How should this Error be NSError?
+                if error != nil { // How should this Error be NSError?
                     
                     let nserror = NSError(domain: "Theo Request", code: 1, userInfo: nil)
                     errorCallBack(nserror, httpResponse)
@@ -310,7 +310,7 @@ class Request {
         
         self.httpRequest = request
         
-        let task : URLSessionDataTask = self.httpSession.session.dataTask(with: self.httpRequest, completionHandler: {(data: Data?, response: URLResponse?, error: NSError?) -> Void in
+        let task : URLSessionDataTask = self.httpSession.session.dataTask(with: self.httpRequest, completionHandler: {(data: Data?, response: URLResponse?, error: Error?) -> Void in
             
             var dataResp: Data? = data
             let httpResponse: HTTPURLResponse = response as! HTTPURLResponse
@@ -329,9 +329,10 @@ class Request {
             
             if let errorCallBack = errorBlock {
                 
-                if let error = error {
+                if error != nil { // How should this Error be NSError?
                     
-                    errorCallBack(error, httpResponse)
+                    let nserror = NSError(domain: "Theo Request", code: 1, userInfo: nil)
+                    errorCallBack(nserror, httpResponse)
                     return
                 }
                 
@@ -346,7 +347,7 @@ class Request {
                     errorCallBack(requestResponseError, httpResponse)
                 }
             }
-        } as! (Data?, URLResponse?, Error?) -> Void)
+        })
         
         task.resume()
     }

--- a/Source/Theo/Theo/Theo.h
+++ b/Source/Theo/Theo/Theo.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 Theo. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+//#import <UIKit/UIKit.h>
 
 //! Project version number for Theo.
 FOUNDATION_EXPORT double TheoVersionNumber;

--- a/Source/Theo/TheoTests/Config.swift
+++ b/Source/Theo/TheoTests/Config.swift
@@ -8,21 +8,20 @@
 
 import Foundation
 
-
 struct Config {
     let username: String
     let password: String
     let host: String
-    
+
     init(pathToFile: String) {
 
         do {
-            
+
             let jsonData: NSData = NSData(contentsOfFile: pathToFile)!
             let JSON: AnyObject? = try JSONSerialization.jsonObject(with: jsonData as Data, options: []) as AnyObject!
 
             let jsonConfig: [String:String]! = JSON as! [String:String]
-            
+
             self.username = jsonConfig["username"]!
             self.password = jsonConfig["password"]!
             self.host     = jsonConfig["host"]!

--- a/Source/Theo/TheoTests/Theo_000_RequestTests.swift
+++ b/Source/Theo/TheoTests/Theo_000_RequestTests.swift
@@ -30,6 +30,8 @@ class Theo_000_RequestTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        
+        continueAfterFailure = false
     }
 
     override func tearDown() {

--- a/Source/Theo/TheoTests/Theo_000_RequestTests.swift
+++ b/Source/Theo/TheoTests/Theo_000_RequestTests.swift
@@ -12,44 +12,45 @@ import XCTest
 let TheoTimeoutInterval: TimeInterval = 10
 var TheoNodeID: String                  = "100"
 var TheoNodeIDForRelationship: String   = "101"
+var TheoNodeIDForUser: String           = "102"
 let TheoNodePropertyName: String        = "title"
 
 class ConfigLoader: NSObject {
-    
+
     class func loadConfig() -> Config {
-        
+
         let filePath: String = Bundle(for: ConfigLoader.classForKeyedArchiver()!).path(forResource: "TheoConfig", ofType: "json")!
-        
+
         return Config(pathToFile: filePath)
     }
 }
 
 class Theo_000_RequestTests: XCTestCase {
-  
+
     let configuration: Config = ConfigLoader.loadConfig()
 
     override func setUp() {
         super.setUp()
-        
+
         continueAfterFailure = false
     }
 
     override func tearDown() {
         super.tearDown()
     }
-  
+
     func test_000_successfullyFetchDBMeta() {
 
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_000_successfullyFetchDBMeta")
-        
+
         theo.metaDescription({(meta, error) in
-          
+
           print("meta in success \(meta) error \(error)")
-          
+
           XCTAssert(meta != nil, "Meta can't be nil")
           XCTAssert(error == nil, "Error must be nil \(error?.description)")
-          
+
           exp.fulfill()
         })
 
@@ -57,18 +58,18 @@ class Theo_000_RequestTests: XCTestCase {
           XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_000_createTestData() {
 
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_000_createTestData")
-        
+
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .short
         dateFormatter.timeStyle = .short
-        
+
         // Data
-        
+
         let title = "Example"
         var postNode = Node()
         postNode.setProp("title", propertyValue: title)
@@ -76,18 +77,17 @@ class Theo_000_RequestTests: XCTestCase {
         postNode.setProp("tagstr", propertyValue: "a, b, c")
         postNode.setProp("timestamp", propertyValue: dateFormatter.string(from: Date()))
         postNode.setProp("url", propertyValue: "http://somewhere.out.there/post/1")
-        
+
         let userUsername = "ajordan"
         var userNode = Node()
         userNode.setProp("username", propertyValue: userUsername as AnyObject)
-        
+
         let followingUsername = "hhansen"
         var followingNode = Node()
         followingNode.setProp("username", propertyValue: followingUsername as AnyObject)
 
-        
         // Create nodes
-        
+
         let createDispatchGroup: DispatchGroup = DispatchGroup()
 
         createDispatchGroup.enter()
@@ -96,12 +96,12 @@ class Theo_000_RequestTests: XCTestCase {
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
 
-            if let identifier = node?.meta?.nodeID(){
+            if let identifier = node?.meta?.nodeID() {
                 TheoNodeID = identifier
             } else {
                 XCTFail("Could not get newly created node identifier")
             }
-            
+
             if let nodeTitle = node?.getProp("title") as? String {
                 XCTAssertEqual(title, nodeTitle, "Title in should be title out")
             } else {
@@ -119,18 +119,19 @@ class Theo_000_RequestTests: XCTestCase {
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
-            
-            if (node?.meta?.nodeID()) != nil {
+
+            if let identifier = node?.meta?.nodeID() {
+                TheoNodeIDForUser = identifier
             } else {
                 XCTFail("Could not get newly created node identifier")
             }
-            
+
             if let username = node?.getProp("username") as? String {
                 XCTAssertEqual(userUsername, username, "Username in should be username out")
             } else {
                 XCTFail("Could not get newly created node property: title")
             }
-            
+
             if let node = node {
                 userNode = node
             }
@@ -142,19 +143,19 @@ class Theo_000_RequestTests: XCTestCase {
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
-            
-            if let identifier = node?.meta?.nodeID(){
+
+            if let identifier = node?.meta?.nodeID() {
                 TheoNodeIDForRelationship = identifier
             } else {
                 XCTFail("Could not get newly created node identifier")
             }
-            
+
             if let username = node?.getProp("username") as? String {
                 XCTAssertEqual(followingUsername, username, "Username in should be username out")
             } else {
                 XCTFail("Could not get newly created node property: username")
             }
-            
+
             if let node = node {
                 followingNode = node
             }
@@ -162,144 +163,142 @@ class Theo_000_RequestTests: XCTestCase {
         }
 
         // Wait for creation to make relationships
-        
+
         createDispatchGroup.notify(queue: DispatchQueue.main) {
 
             // Data
             let followingRelationship = Relationship()
             followingRelationship.relate(userNode, toNode: followingNode, type: RelationshipType.FOLLOWS)
             followingRelationship.setProp("startTime", propertyValue: dateFormatter.string(from: Date()) as AnyObject)
-            
+
             let lastPostRelationship = Relationship()
             lastPostRelationship.relate(followingNode, toNode: postNode, type: RelationshipType.LASTPOST)
             lastPostRelationship.setProp("postTime", propertyValue: dateFormatter.string(from: Date()) as AnyObject)
-            
+
             let nextPostRelationship = Relationship()
             nextPostRelationship.relate(postNode, toNode: userNode, type: RelationshipType.NEXTPOST)
             nextPostRelationship.setProp("scheduledTime", propertyValue: dateFormatter.string(from: Date()) as AnyObject)
 
-            
             // Create relationships
-            
+
             let relateDispatchGroup = DispatchGroup()
-            
+
             relateDispatchGroup.enter()
             theo.createRelationship(followingRelationship, completionBlock: { (relationship, error) in
-                
+
                 XCTAssert(relationship != nil, "Relationship data can't be nil")
                 XCTAssert(error == nil, "Error must be nil \(error?.description)")
-                
+
                 relateDispatchGroup.leave()
             })
-            
+
             relateDispatchGroup.enter()
             theo.createRelationship(lastPostRelationship, completionBlock: { (relationship, error) in
-                
+
                 XCTAssert(relationship != nil, "Relationship data can't be nil")
                 XCTAssert(error == nil, "Error must be nil \(error?.description)")
-                
+
                 relateDispatchGroup.leave()
             })
-            
+
             relateDispatchGroup.enter()
             theo.createRelationship(nextPostRelationship, completionBlock: { (relationship, error) in
-                
+
                 XCTAssert(relationship != nil, "Relationship data can't be nil")
                 XCTAssert(error == nil, "Error must be nil \(error?.description)")
-                
+
                 relateDispatchGroup.leave()
             })
-            
+
             relateDispatchGroup.notify(queue: DispatchQueue.main) {
-                
+
                 exp.fulfill()
             }
         }
 
-        
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_001_successfullyFetchNode() {
-    
+
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_002_successfullyFetchNode")
-        
+
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
-            
+
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
-            
+
             print("meta in success \(node?.meta) node \(node) error \(error)")
-            
+
             exp.fulfill()
         })
-        
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_002_successfullyAccessProperty() {
-    
+
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_002_successfullyAccessProperty")
-        
+
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
-            
+
             print("meta in success \(node?.meta) [node \(node)] error \(error)")
-            
+
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssertNotNil(node, "Node data can't be nil")
             XCTAssertNil(error, "Error must be nil \(error?.description)")
-            
+
             if let nodeObject: Node = node {
                 let nodePropertyValue: AnyObject? = nodeObject.getProp(TheoNodePropertyName)
-                
+
                 XCTAssert(nodePropertyValue != nil, "The nodeProperty can't be nil")
-                
+
                 exp.fulfill()
             }
         })
-        
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_003_successfullyHandleNonExistantAccessProperty() {
-        
+
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_003_successfullyHandleNonExistantAccessProperty")
         let randomString: String = NSUUID().uuidString
-        
+
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
-            
+
             print("meta in success \(node?.meta) node \(node) error \(error)")
-            
+
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
-            
+
             if let nodeObject: Node = node {
                 let nodePropertyValue: AnyObject? = nodeObject.getProp(randomString)
-                
+
                 XCTAssertNil(nodePropertyValue, "The nodeProperty must be nil")
-                
+
                 exp.fulfill()
             }
         })
-        
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_004_successfullyAddNodeWithOutLabels() {
-    
+
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_004_successfullyAddNodeWithOutLabels")
         let node = Node()
@@ -307,78 +306,78 @@ class Theo_000_RequestTests: XCTestCase {
 
         node.setProp("unitTestKey_1", propertyValue: ("unitTestValue_1" + randomString) as AnyObject)
         node.setProp("unitTestKey_2", propertyValue: ("unitTestValue_2" + randomString) as AnyObject)
-        
+
         theo.createNode(node, completionBlock: {(node, error) in
-        
+
             print("new node \(node)")
-            
+
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
-            
+
             exp.fulfill()
-        });
-        
+        })
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_005_successfullyAddRelationship() {
 
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_005_successfullyAddRelationship")
-        
+
         /**
          * Setup dispatch group since you to make a 2 part transation
          */
 
         let fetchDispatchGroup: DispatchGroup = DispatchGroup()
-        
+
         var parentNode: Node?
         var relatedNode: Node?
         let relationship: Relationship = Relationship()
-        
+
         /**
          * Fetch the parent node
          */
-        
+
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
-            
+
             print("meta in success \(node?.meta) node \(node) error \(error)")
-            
+
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
-            
+
             if let nodeObject: Node = node {
                 parentNode = nodeObject
             }
-            
+
             fetchDispatchGroup.leave()
         })
-        
+
         /**
          * Fetch the related node
          */
 
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeIDForRelationship, completionBlock: {(node, error) in
-            
+
             print("meta in success \(node?.meta) node \(node) error \(error)")
-            
+
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
-          
+
             if let nodeObject: Node = node {
                 relatedNode = nodeObject
             }
-            
+
             fetchDispatchGroup.leave()
         })
-        
+
         /**
          * End it
          */
@@ -387,94 +386,94 @@ class Theo_000_RequestTests: XCTestCase {
 
             XCTAssertNotNil(parentNode, "parent node can't be nil")
             XCTAssertNotNil(relatedNode, "relatedNode node can't be nil")
-            
+
             guard let parentNode = parentNode,
                 let relatedNode = relatedNode else {
                     XCTFail("These nodes must have been defined")
                     return
             }
-            
+
             relationship.relate(parentNode, toNode: relatedNode, type: RelationshipType.KNOWS)
             relationship.setProp("my_relationship_property_name", propertyValue: "my_relationship_property_value")
 
             theo.createRelationship(relationship, completionBlock: {(rel, error) in
-            
+
                 XCTAssert(rel?.relationshipMeta != nil, "Meta data can't be nil")
                 XCTAssert(rel != nil, "Node data can't be nil")
                 XCTAssert(error == nil, "Error must be nil \(error?.description)")
-                
+
                 exp.fulfill()
             })
         }
-        
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_006_succesfullyUpdateNodeWithProperties() {
-    
+
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_006_succesfullyUpdateNodeWithProperties")
-        
+
        /**
         * Setup dispatch group since you to make a 2 part transation
         */
 
         let fetchDispatchGroup: DispatchGroup = DispatchGroup()
-        
+
         var updateNode: Node?
-       
+
        /**
         * Fetch the parent node
         */
-        
+
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
-            
+
             print("test_008_succesfullyUpdateNodeWithProperties \(node?.meta) node \(node) error \(error)")
 
             XCTAssertNotNil(node, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
-            
+
             if let nodeObject: Node = node {
 
                 updateNode = nodeObject
-                
+
                 XCTAssert(node?.meta != nil, "Meta data can't be nil")
             }
-            
+
             fetchDispatchGroup.leave()
         })
-        
+
        /**
         * End it
         */
-        
+
         fetchDispatchGroup.notify(queue: DispatchQueue.main) {
-            
+
             XCTAssertNotNil(updateNode, "updateNode node can't be nil")
             guard let updateNode = updateNode else {
                 XCTFail("Node not defined, abort further testing")
                 return
             }
-            
+
             let updatedPropertiesDictionary: [String:AnyObject] = ["test_update_property_label_1": "test_update_property_lable_2" as AnyObject]
-            
+
             theo.updateNode(updateNode, properties: updatedPropertiesDictionary,
-                completionBlock: {(node, error) in
-            
+                completionBlock: {(_, error) in
+
                     XCTAssert(error == nil, "Error must be nil \(error?.description)")
-                    
+
                     exp.fulfill()
             })
         }
-        
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_007_successfullyDeleteRelationship() {
 
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
@@ -484,60 +483,59 @@ class Theo_000_RequestTests: XCTestCase {
 
         var relationshipIDToDelete: String?
         var nodeIDWithRelationships: String?
-        
+
         /**
          * Fetch relationship for main RUD node
          */
-        
+
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
-            
+
             print("test_007_successfullyDeleteRelationship \(node?.meta) node \(node) error \(error)")
-            
+
             XCTAssertNotNil(node, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
-            
+
             if let nodeObject: Node = node {
-                
+
                 XCTAssert(node?.meta != nil, "Meta data can't be nil")
-                
+
                 nodeIDWithRelationships = nodeObject.meta!.nodeID()
-                
-                XCTAssertNotNil(nodeIDWithRelationships, "nodeIDWithRelationships for relationships deletion can't be nil");
+
+                XCTAssertNotNil(nodeIDWithRelationships, "nodeIDWithRelationships for relationships deletion can't be nil")
             }
-            
+
             fetchDispatchGroup.leave()
         })
 
-        
         /**
          * Delete the relationship
          */
 
         fetchDispatchGroup.notify(queue: DispatchQueue.main) {
-            
+
             guard let nodeIDWithRelationships = nodeIDWithRelationships else {
                 XCTFail("Abort, nodeIDWithRelationships was nil")
                 return
             }
-            
+
             theo.fetchRelationshipsForNode(nodeIDWithRelationships, direction: RelationshipDirection.ALL, types: nil, completionBlock: {(relationships, error) in
-                
+
                 XCTAssert(relationships.count >= 1, "Relationships must be exist")
                 XCTAssertNil(error, "Error should be nil \(error)")
-                
+
                 if let foundRelationship: Relationship = relationships[0] as Relationship! {
-                    
+
                     if let relMeta: RelationshipMeta = foundRelationship.relationshipMeta {
                         relationshipIDToDelete = relMeta.relationshipID()
                     }
 
                     XCTAssertNotNil(relationshipIDToDelete, "relationshipIDToDelete can't be nil")
-                    
+
                     theo.deleteRelationship(relationshipIDToDelete!, completionBlock: {error in
-                        
+
                         XCTAssertNil(error, "Error should be nil \(error)")
-                        
+
                         exp.fulfill()
                     })
                 }
@@ -548,14 +546,14 @@ class Theo_000_RequestTests: XCTestCase {
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_008_succesfullyAddNodeWithLabels() {
-        
+
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_008_succesfullyAddNodeWithLabel")
         let node = Node()
         let randomString: String = NSUUID().uuidString
-        
+
         node.setProp("succesfullyAddNodeWithLabel_1", propertyValue: "succesfullyAddNodeWithLabel_1" + randomString)
         node.setProp("succesfullyAddNodeWithLabel_2", propertyValue: "succesfullyAddNodeWithLabel_2" + randomString)
         node.setProp("succesfullyAddNodeWithLabel_3", propertyValue: 123456 as AnyObject)
@@ -573,175 +571,205 @@ class Theo_000_RequestTests: XCTestCase {
 
             exp.fulfill()
         })
-        
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_009_successfullyCommitTransaction() {
 
-        let createStatement: String = "CREATE ( bike:Bike { weight: 10 } ) CREATE ( frontWheel:Wheel { spokes: 3 } ) CREATE ( backWheel:Wheel { spokes: 32 } ) CREATE p1 = bike -[:HAS { position: 1 } ]-> frontWheel CREATE p2 = bike -[:HAS { position: 2 } ]-> backWheel RETURN bike, p1, p2"        
+        let createStatement: String = "CREATE ( bike:Bike { weight: 10 } ) CREATE ( frontWheel:Wheel { spokes: 3 } ) CREATE ( backWheel:Wheel { spokes: 32 } ) CREATE p1 = bike -[:HAS { position: 1 } ]-> frontWheel CREATE p2 = bike -[:HAS { position: 2 } ]-> backWheel RETURN bike, p1, p2"
         let resultDataContents: Array<String> = ["REST"]
-        let statement: Dictionary <String, AnyObject> = ["statement" : createStatement as AnyObject, "resultDataContents" : resultDataContents as AnyObject]
+        let statement: Dictionary <String, AnyObject> = ["statement": createStatement as AnyObject, "resultDataContents": resultDataContents as AnyObject]
         let statements: Array<Dictionary <String, AnyObject>> = [statement]
-        
+
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_010_successfullyCommitTransaction")
-        
+
         theo.executeTransaction(statements, completionBlock: {(response, error) in
-            
+
             XCTAssertNil(error, "Error must be nil \(error?.description)")
             XCTAssertFalse(response.keys.isEmpty, "Response dictionary must not be empty \(response)")
-            
+
             exp.fulfill()
         })
-        
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_011_succesfullyUpdateRelationshipWithProperties() {
-        
+
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_011_succesfullyUpdateRelationshipWithProperties")
-        
+
         let fetchDispatchGroup = DispatchGroup()
-        
+
         var nodeIDWithRelationships: String?
-        
+
         // Fetch relationship for main RUD node
-        
+
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
-            
+
             print("test_011_succesfullyUpdateRelationshipWithProperties \(node?.meta) node \(node) error \(error)")
-            
+
             XCTAssertNotNil(node, "Node data can't be nil")
             XCTAssertNil(error, "Error must be nil \(error?.description)")
-            
+
             if let nodeObject: Node = node {
-                
+
                 XCTAssert(node?.meta != nil, "Meta data can't be nil")
-                
+
                 nodeIDWithRelationships = nodeObject.meta!.nodeID()
-                
-                XCTAssertNotNil(nodeIDWithRelationships, "nodeIDWithRelationships for relationships deletion can't be nil");
+
+                XCTAssertNotNil(nodeIDWithRelationships, "nodeIDWithRelationships for relationships deletion can't be nil")
             }
-            
+
             fetchDispatchGroup.leave()
         })
-        
+
         // Delete the relationship
-        
+
         fetchDispatchGroup.notify(queue: DispatchQueue.main) {
-            
+
             guard let nodeIDWithRelationships = nodeIDWithRelationships else {
                 XCTFail("nodeIDWithRelationships not defined")
                 return
             }
             theo.fetchRelationshipsForNode(nodeIDWithRelationships, direction: RelationshipDirection.ALL, types: nil, completionBlock: {(relationships, error) in
-                
+
                 XCTAssert(relationships.count >= 1, "Relationships must exist")
                 XCTAssertNil(error, "Error should be nil \(error)")
-                
+
                 if let foundRelationship: Relationship = relationships.first {
 
-                    let updatedProperties: Dictionary<String, AnyObject> = ["updatedRelationshipProperty" : "updatedRelationshipPropertyValue" as AnyObject]
-                    
+                    let updatedProperties: Dictionary<String, AnyObject> = ["updatedRelationshipProperty": "updatedRelationshipPropertyValue" as AnyObject]
+
                     theo.updateRelationship(foundRelationship, properties: updatedProperties, completionBlock: {(_, error) in
 
                         XCTAssertNil(error, "Error should be nil \(error)")
-                        
+
                         exp.fulfill()
                     })
-                    
+
                 } else {
 
                     XCTFail("no relationships where found")
-                    
+
                     exp.fulfill()
                 }
             })
         }
-        
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
-    
+
     func test_012_successfullyExecuteCyperRequest() {
 
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_012_successfullyExecuteCyperRequest")
         let cyperQuery: String = "MATCH (u:User {username: {user} }) WITH u MATCH (u)-[:FOLLOWS*0..1]->(f) WITH DISTINCT f,u MATCH (f)-[:LASTPOST]-(lp)-[:NEXTPOST*0..3]-(p) RETURN p.contentId as contentId, p.title as title, p.tagstr as tagstr, p.timestamp as timestamp, p.url as url, f.username as username, f=u as owner"
-        let cyperParams: Dictionary<String, AnyObject> = ["user" : "ajordan" as AnyObject]
+        let cyperParams: Dictionary<String, AnyObject> = ["user": "ajordan" as AnyObject]
 
         theo.executeCypher(cyperQuery, params: cyperParams, completionBlock: {(cypher, error) in
-            
+
             XCTAssertNil(error, "Error should be nil \(error)")
             XCTAssertNotNil(cypher, "Response can't be nil")
-            
+
             exp.fulfill()
         })
-        
+
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
     
-    func test_999_successfullyDeleteExistingNode() {
-
+    func test_998_successfullyDeleteExistingNode() {
+        
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_999_successfullyDeleteExistingNode")
-
+        
         var nodeIDForDeletion: String?
         let node = Node()
         let randomString: String = NSUUID().uuidString
-
+        
         let createDispatchGroup = DispatchGroup()
-
+        
         createDispatchGroup.enter()
-
+        
         node.setProp("test_010_successfullyDeleteExistingNode_1", propertyValue: "test_010_successfullyDeleteExistingNode_1" + randomString)
         node.setProp("test_010_successfullyDeleteExistingNode_2", propertyValue: "test_010_successfullyDeleteExistingNode_2" + randomString)
-
+        
         theo.createNode(node, completionBlock: {(savedNode, error) in
-
+            
             XCTAssertNil(error, "Error must be nil \(error?.description)")
             XCTAssertNotNil(savedNode, "Saved node can't be nil")
-
+            
             nodeIDForDeletion = savedNode?.meta?.nodeID()
-
+            
             createDispatchGroup.leave()
         })
-
+        
         createDispatchGroup.notify(queue: DispatchQueue.main) {
-
+            
             XCTAssertNotNil(nodeIDForDeletion, "nodeIDForDeletion must NOT be nil")
             guard let nodeIDForDeletion = nodeIDForDeletion else {
                 XCTFail("nodeIDForDeletion was not defined")
                 return
             }
-
+            
             theo.deleteNode(nodeIDForDeletion, completionBlock: {error in
-
+                
                 XCTAssertNil(error, "Error should be nil \(error)")
-
+                
                 exp.fulfill()
             })
+        }
+        
+        self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
+            XCTAssertNil(error, "\(error)")
+        })
+    }
+
+    func test_999_cleanupTests() {
+        let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
+
+        let cleanupDispatchGroup: DispatchGroup = DispatchGroup()
+
+        let completionBlock = { (error: NSError?) in
+            cleanupDispatchGroup.leave()
+        }
+
+        cleanupDispatchGroup.enter()
+        theo.deleteNode(TheoNodeID, completionBlock: completionBlock)
+
+        cleanupDispatchGroup.enter()
+        theo.deleteNode(TheoNodeIDForRelationship, completionBlock: completionBlock)
+
+        cleanupDispatchGroup.enter()
+        theo.deleteNode(TheoNodeIDForUser, completionBlock: completionBlock)
+
+        let exp = self.expectation(description: "cleanup")
+        cleanupDispatchGroup.notify(queue: DispatchQueue.main) {
+            exp.fulfill()
         }
 
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
     }
+
+
 }
 
 extension Node {
     func setProp(_ propertyName: String, propertyValue: String) -> Void {
-        
+
         let value: AnyObject = propertyValue as NSString
         self.setProp(propertyName, propertyValue: value)
     }
@@ -749,14 +777,14 @@ extension Node {
 
 extension Relationship {
     func setProp(_ propertyName: String, propertyValue: String) -> Void {
-        
+
         let value: AnyObject = propertyValue as NSString
         self.setProp(propertyName, propertyValue: value)
     }
 }
 
 extension RelationshipType {
-    
+
     public static var FOLLOWS: String  = "FOLLOWS"
     public static var LASTPOST: String = "LASTPOST"
     public static var NEXTPOST: String = "NEXTPOST"

--- a/Source/Theo/TheoTests/Theo_000_RequestTests.swift
+++ b/Source/Theo/TheoTests/Theo_000_RequestTests.swift
@@ -68,7 +68,7 @@ class Theo_000_RequestTests: XCTestCase {
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
             
-            print("meta in success \(node!.meta) node \(node) error \(error)")
+            print("meta in success \(node?.meta ?? "Undefined") node \(node) error \(error)")
             
             exp.fulfill()
         })

--- a/Source/Theo/TheoTests/Theo_000_RequestTests.swift
+++ b/Source/Theo/TheoTests/Theo_000_RequestTests.swift
@@ -6,7 +6,6 @@
 //  Copyright (c) 2014 Theo. All rights reserved.
 //
 
-import UIKit
 import Foundation
 import XCTest
 

--- a/Source/Theo/TheoTests/Theo_000_RequestTests.swift
+++ b/Source/Theo/TheoTests/Theo_000_RequestTests.swift
@@ -68,7 +68,7 @@ class Theo_000_RequestTests: XCTestCase {
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
             
-            print("meta in success \(node?.meta ?? "Undefined") node \(node) error \(error)")
+            print("meta in success \(node?.meta) node \(node) error \(error)")
             
             exp.fulfill()
         })
@@ -85,18 +85,19 @@ class Theo_000_RequestTests: XCTestCase {
         
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
             
-            print("meta in success \(node!.meta) [node \(node)] error \(error)")
+            print("meta in success \(node?.meta) [node \(node)] error \(error)")
             
-            XCTAssert(node!.meta != nil, "Meta data can't be nil")
+            XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssertNotNil(node, "Node data can't be nil")
             XCTAssertNil(error, "Error must be nil \(error?.description)")
             
-            let nodeObject: Node = node!
-            let nodePropertyValue: AnyObject? = nodeObject.getProp(TheoNodePropertyName)
-            
-            XCTAssert(nodePropertyValue != nil, "The nodeProperty can't be nil")
-            
-            exp.fulfill()
+            if let nodeObject: Node = node {
+                let nodePropertyValue: AnyObject? = nodeObject.getProp(TheoNodePropertyName)
+                
+                XCTAssert(nodePropertyValue != nil, "The nodeProperty can't be nil")
+                
+                exp.fulfill()
+            }
         })
         
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
@@ -112,18 +113,19 @@ class Theo_000_RequestTests: XCTestCase {
         
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
             
-            print("meta in success \(node!.meta) node \(node) error \(error)")
+            print("meta in success \(node?.meta) node \(node) error \(error)")
             
-            XCTAssert(node!.meta != nil, "Meta data can't be nil")
+            XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
             
-            let nodeObject: Node = node!
-            let nodePropertyValue: AnyObject? = nodeObject.getProp(randomString)
-
-            XCTAssertNil(nodePropertyValue, "The nodeProperty must be nil")
-            
-            exp.fulfill()
+            if let nodeObject: Node = node {
+                let nodePropertyValue: AnyObject? = nodeObject.getProp(randomString)
+                
+                XCTAssertNil(nodePropertyValue, "The nodeProperty must be nil")
+                
+                exp.fulfill()
+            }
         })
         
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
@@ -145,7 +147,7 @@ class Theo_000_RequestTests: XCTestCase {
         
             print("new node \(node)")
             
-            XCTAssert(node!.meta != nil, "Meta data can't be nil")
+            XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
             
@@ -179,9 +181,9 @@ class Theo_000_RequestTests: XCTestCase {
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
             
-            print("meta in success \(node!.meta) node \(node) error \(error)")
+            print("meta in success \(node?.meta) node \(node) error \(error)")
             
-            XCTAssert(node!.meta != nil, "Meta data can't be nil")
+            XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(node != nil, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
             
@@ -199,7 +201,7 @@ class Theo_000_RequestTests: XCTestCase {
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeIDForRelationship, completionBlock: {(node, error) in
             
-            print("meta in success \(node!.meta) node \(node) error \(error)")
+            print("meta in success \(node?.meta) node \(node) error \(error)")
             
             XCTAssert(node?.meta != nil, "Meta data can't be nil")
             XCTAssert(node != nil, "Node data can't be nil")
@@ -221,7 +223,13 @@ class Theo_000_RequestTests: XCTestCase {
             XCTAssertNotNil(parentNode, "parent node can't be nil")
             XCTAssertNotNil(relatedNode, "relatedNode node can't be nil")
             
-            relationship.relate(parentNode!, toNode: relatedNode!, type: RelationshipType.KNOWS)
+            guard let parentNode = parentNode,
+                let relatedNode = relatedNode else {
+                    XCTFail("These nodes must have been defined")
+                    return
+            }
+            
+            relationship.relate(parentNode, toNode: relatedNode, type: RelationshipType.KNOWS)
             relationship.setProp("my_relationship_property_name", propertyValue: "my_relationship_property_value")
 
             theo.createRelationship(relationship, completionBlock: {(rel, error) in
@@ -259,7 +267,7 @@ class Theo_000_RequestTests: XCTestCase {
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
             
-            print("test_008_succesfullyUpdateNodeWithProperties \(node!.meta) node \(node) error \(error)")
+            print("test_008_succesfullyUpdateNodeWithProperties \(node?.meta) node \(node) error \(error)")
 
             XCTAssertNotNil(node, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
@@ -268,7 +276,7 @@ class Theo_000_RequestTests: XCTestCase {
 
                 updateNode = nodeObject
                 
-                XCTAssert(node!.meta != nil, "Meta data can't be nil")
+                XCTAssert(node?.meta != nil, "Meta data can't be nil")
             }
             
             fetchDispatchGroup.leave()
@@ -281,10 +289,14 @@ class Theo_000_RequestTests: XCTestCase {
         fetchDispatchGroup.notify(queue: DispatchQueue.main) {
             
             XCTAssertNotNil(updateNode, "updateNode node can't be nil")
+            guard let updateNode = updateNode else {
+                XCTFail("Node not defined, abort further testing")
+                return
+            }
             
             let updatedPropertiesDictionary: [String:AnyObject] = ["test_update_property_label_1": "test_update_property_lable_2" as AnyObject]
             
-            theo.updateNode(updateNode!, properties: updatedPropertiesDictionary,
+            theo.updateNode(updateNode, properties: updatedPropertiesDictionary,
                 completionBlock: {(node, error) in
             
                     XCTAssert(error == nil, "Error must be nil \(error?.description)")
@@ -315,14 +327,14 @@ class Theo_000_RequestTests: XCTestCase {
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
             
-            print("test_007_successfullyDeleteRelationship \(node!.meta) node \(node) error \(error)")
+            print("test_007_successfullyDeleteRelationship \(node?.meta) node \(node) error \(error)")
             
             XCTAssertNotNil(node, "Node data can't be nil")
             XCTAssert(error == nil, "Error must be nil \(error?.description)")
             
             if let nodeObject: Node = node {
                 
-                XCTAssert(node!.meta != nil, "Meta data can't be nil")
+                XCTAssert(node?.meta != nil, "Meta data can't be nil")
                 
                 nodeIDWithRelationships = nodeObject.meta!.nodeID()
                 
@@ -339,7 +351,12 @@ class Theo_000_RequestTests: XCTestCase {
 
         fetchDispatchGroup.notify(queue: DispatchQueue.main) {
             
-            theo.fetchRelationshipsForNode(nodeIDWithRelationships!, direction: RelationshipDirection.ALL, types: nil, completionBlock: {(relationships, error) in
+            guard let nodeIDWithRelationships = nodeIDWithRelationships else {
+                XCTFail("Abort, nodeIDWithRelationships was nil")
+                return
+            }
+            
+            theo.fetchRelationshipsForNode(nodeIDWithRelationships, direction: RelationshipDirection.ALL, types: nil, completionBlock: {(relationships, error) in
                 
                 XCTAssert(relationships.count >= 1, "Relationships must be exist")
                 XCTAssertNil(error, "Error should be nil \(error)")
@@ -383,7 +400,11 @@ class Theo_000_RequestTests: XCTestCase {
 
             XCTAssertNil(error, "Error must be nil \(error?.description)")
             XCTAssertNotNil(savedNode, "Node can't be nil")
-            XCTAssertFalse(savedNode!.labels.isEmpty, "Labels must be set")
+            guard let savedNode = savedNode else {
+                XCTFail("Assert fell through, abort")
+                return
+            }
+            XCTAssertFalse(savedNode.labels.isEmpty, "Labels must be set")
 
             exp.fulfill()
         })
@@ -430,7 +451,7 @@ class Theo_000_RequestTests: XCTestCase {
         fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
             
-            print("test_011_succesfullyUpdateRelationshipWithProperties \(node!.meta) node \(node) error \(error)")
+            print("test_011_succesfullyUpdateRelationshipWithProperties \(node?.meta) node \(node) error \(error)")
             
             XCTAssertNotNil(node, "Node data can't be nil")
             XCTAssertNil(error, "Error must be nil \(error?.description)")
@@ -451,7 +472,11 @@ class Theo_000_RequestTests: XCTestCase {
         
         fetchDispatchGroup.notify(queue: DispatchQueue.main) {
             
-            theo.fetchRelationshipsForNode(nodeIDWithRelationships!, direction: RelationshipDirection.ALL, types: nil, completionBlock: {(relationships, error) in
+            guard let nodeIDWithRelationships = nodeIDWithRelationships else {
+                XCTFail("nodeIDWithRelationships not defined")
+                return
+            }
+            theo.fetchRelationshipsForNode(nodeIDWithRelationships, direction: RelationshipDirection.ALL, types: nil, completionBlock: {(relationships, error) in
                 
                 XCTAssert(relationships.count >= 1, "Relationships must be exist")
                 XCTAssertNil(error, "Error should be nil \(error)")
@@ -522,7 +547,7 @@ class Theo_000_RequestTests: XCTestCase {
             XCTAssertNil(error, "Error must be nil \(error?.description)")
             XCTAssertNotNil(savedNode, "Saved node can't be nil")
 
-            nodeIDForDeletion = savedNode!.meta?.nodeID()
+            nodeIDForDeletion = savedNode?.meta?.nodeID()
 
             createDispatchGroup.leave()
         })
@@ -530,8 +555,12 @@ class Theo_000_RequestTests: XCTestCase {
         createDispatchGroup.notify(queue: DispatchQueue.main) {
 
             XCTAssertNotNil(nodeIDForDeletion, "nodeIDForDeletion must NOT be nil")
+            guard let nodeIDForDeletion = nodeIDForDeletion else {
+                XCTFail("nodeIDForDeletion was not defined")
+                return
+            }
 
-            theo.deleteNode(nodeIDForDeletion!, completionBlock: {error in
+            theo.deleteNode(nodeIDForDeletion, completionBlock: {error in
 
                 XCTAssertNil(error, "Error should be nil \(error)")
 

--- a/Source/Theo/TheoTests/Theo_000_RequestTests.swift
+++ b/Source/Theo/TheoTests/Theo_000_RequestTests.swift
@@ -216,7 +216,7 @@ class Theo_000_RequestTests: XCTestCase {
          * End it
          */
 //http://stackoverflow.com/questions/38552180/dispatch-group-cannot-notify-to-main-thread
-        dispatch_group_notify(fetchDispatchGroup, DispatchQueue.global(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+        fetchDispatchGroup.notify(queue: DispatchQueue.main) {
 
             XCTAssertNotNil(parentNode, "parent node can't be nil")
             XCTAssertNotNil(relatedNode, "relatedNode node can't be nil")
@@ -232,7 +232,7 @@ class Theo_000_RequestTests: XCTestCase {
                 
                 exp.fulfill()
             })
-        })
+        }
         
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
@@ -248,7 +248,7 @@ class Theo_000_RequestTests: XCTestCase {
         * Setup dispatch group since you to make a 2 part transation
         */
 
-        let fetchDispatchGroup: dispatch_group_t = dispatch_group_create()
+        let fetchDispatchGroup: DispatchGroup = DispatchGroup()
         
         var updateNode: Node?
        
@@ -256,7 +256,7 @@ class Theo_000_RequestTests: XCTestCase {
         * Fetch the parent node
         */
         
-        dispatch_group_enter(fetchDispatchGroup)
+        fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
             
             print("test_008_succesfullyUpdateNodeWithProperties \(node!.meta) node \(node) error \(error)")
@@ -278,11 +278,11 @@ class Theo_000_RequestTests: XCTestCase {
         * End it
         */
         
-        dispatch_group_notify(fetchDispatchGroup, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+        fetchDispatchGroup.notify(queue: DispatchQueue.main) {
             
             XCTAssertNotNil(updateNode, "updateNode node can't be nil")
             
-            let updatedPropertiesDictionary: [String:String] = ["test_update_property_label_1": "test_update_property_lable_2"]
+            let updatedPropertiesDictionary: [String:AnyObject] = ["test_update_property_label_1": "test_update_property_lable_2" as AnyObject]
             
             theo.updateNode(updateNode!, properties: updatedPropertiesDictionary,
                 completionBlock: {(node, error) in
@@ -291,7 +291,7 @@ class Theo_000_RequestTests: XCTestCase {
                     
                     exp.fulfill()
             })
-        })
+        }
         
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
@@ -303,7 +303,7 @@ class Theo_000_RequestTests: XCTestCase {
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_007_successfullyDeleteRelationship")
 
-        let fetchDispatchGroup: dispatch_group_t = dispatch_group_create()
+        let fetchDispatchGroup = DispatchGroup()
 
         var relationshipIDToDelete: String?
         var nodeIDWithRelationships: String?
@@ -312,7 +312,7 @@ class Theo_000_RequestTests: XCTestCase {
          * Fetch relationship for main RUD node
          */
         
-        dispatch_group_enter(fetchDispatchGroup)
+        fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
             
             print("test_007_successfullyDeleteRelationship \(node!.meta) node \(node) error \(error)")
@@ -337,7 +337,7 @@ class Theo_000_RequestTests: XCTestCase {
          * Delete the relationship
          */
 
-        dispatch_group_notify(fetchDispatchGroup, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+        fetchDispatchGroup.notify(queue: DispatchQueue.main) {
             
             theo.fetchRelationshipsForNode(nodeIDWithRelationships!, direction: RelationshipDirection.ALL, types: nil, completionBlock: {(relationships, error) in
                 
@@ -360,7 +360,7 @@ class Theo_000_RequestTests: XCTestCase {
                     })
                 }
             })
-        })
+        }
 
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
@@ -421,13 +421,13 @@ class Theo_000_RequestTests: XCTestCase {
         let theo: Client = Client(baseURL: configuration.host, user: configuration.username, pass: configuration.password)
         let exp = self.expectation(description: "test_011_succesfullyUpdateRelationshipWithProperties")
         
-        let fetchDispatchGroup: dispatch_group_t = dispatch_group_create()
+        let fetchDispatchGroup = DispatchGroup()
         
         var nodeIDWithRelationships: String?
         
         // Fetch relationship for main RUD node
         
-        dispatch_group_enter(fetchDispatchGroup)
+        fetchDispatchGroup.enter()
         theo.fetchNode(TheoNodeID, completionBlock: {(node, error) in
             
             print("test_011_succesfullyUpdateRelationshipWithProperties \(node!.meta) node \(node) error \(error)")
@@ -449,7 +449,7 @@ class Theo_000_RequestTests: XCTestCase {
         
         // Delete the relationship
         
-        dispatch_group_notify(fetchDispatchGroup, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+        fetchDispatchGroup.notify(queue: DispatchQueue.main) {
             
             theo.fetchRelationshipsForNode(nodeIDWithRelationships!, direction: RelationshipDirection.ALL, types: nil, completionBlock: {(relationships, error) in
                 
@@ -458,7 +458,7 @@ class Theo_000_RequestTests: XCTestCase {
                 
                 if let foundRelationship: Relationship = relationships[0] as Relationship! {
 
-                    let updatedProperties: Dictionary<String, AnyObject> = ["updatedRelationshipProperty" : "updatedRelationshipPropertyValue"]
+                    let updatedProperties: Dictionary<String, AnyObject> = ["updatedRelationshipProperty" : "updatedRelationshipPropertyValue" as AnyObject]
                     
                     theo.updateRelationship(foundRelationship, properties: updatedProperties, completionBlock: {(_, error) in
 
@@ -474,7 +474,7 @@ class Theo_000_RequestTests: XCTestCase {
                     exp.fulfill()
                 }
             })
-        })
+        }
         
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
@@ -510,9 +510,9 @@ class Theo_000_RequestTests: XCTestCase {
         let node = Node()
         let randomString: String = NSUUID().uuidString
 
-        let createDispatchGroup: dispatch_group_t = dispatch_group_create()
+        let createDispatchGroup = DispatchGroup()
 
-        dispatch_group_enter(createDispatchGroup)
+        createDispatchGroup.enter()
 
         node.setProp("test_010_successfullyDeleteExistingNode_1", propertyValue: "test_010_successfullyDeleteExistingNode_1" + randomString)
         node.setProp("test_010_successfullyDeleteExistingNode_2", propertyValue: "test_010_successfullyDeleteExistingNode_2" + randomString)
@@ -527,7 +527,7 @@ class Theo_000_RequestTests: XCTestCase {
             createDispatchGroup.leave()
         })
 
-        dispatch_group_notify(createDispatchGroup, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), {
+        createDispatchGroup.notify(queue: DispatchQueue.main) {
 
             XCTAssertNotNil(nodeIDForDeletion, "nodeIDForDeletion must NOT be nil")
 
@@ -537,10 +537,26 @@ class Theo_000_RequestTests: XCTestCase {
 
                 exp.fulfill()
             })
-        })
+        }
 
         self.waitForExpectations(timeout: TheoTimeoutInterval, handler: {error in
             XCTAssertNil(error, "\(error)")
         })
+    }
+}
+
+extension Node {
+    func setProp(_ propertyName: String, propertyValue: String) -> Void {
+        
+        let value: AnyObject = propertyValue as NSString
+        self.setProp(propertyName, propertyValue: value)
+    }
+}
+
+extension Relationship {
+    func setProp(_ propertyName: String, propertyValue: String) -> Void {
+        
+        let value: AnyObject = propertyValue as NSString
+        self.setProp(propertyName, propertyValue: value)
     }
 }


### PR DESCRIPTION
Based on pull request #22, this pull request
- success block is no longer called upon error
- tests stop on failed asserts
- fix syntax error in example cypher query
- generate test data so tests run successfully

Based on this pull request, I suggest further work:
- restructure tests so that they do not rely upon ordering or assertion fails
- clean up test data on test teardown
- separate unit tests from integration tests
- don't rely on ! to indicate API usage errors to the user, but have a more descriptive feedback mechanism, that the app can recover from